### PR TITLE
Fix platforms with "broken" SecurityManagers

### DIFF
--- a/src/main/java/io.helins.linux.io/io/helins/linux/io/LinuxIO.java
+++ b/src/main/java/io.helins.linux.io/io/helins/linux/io/LinuxIO.java
@@ -31,7 +31,7 @@ public class LinuxIO {
 
     static {
     
-        Native.register( "c" ) ;
+        Native.register( LinuxIO.class, "c" ) ;
     }
 
 


### PR DESCRIPTION
When I tried to use `linux-i2c` on Android (manually selecting the aar version of JNA in Gradle), an `IllegalStateException` was thrown with the description "The SecurityManager implementation on this platform is broken; you must explicitly provide the class to register". This PR explicitly provides the class, which fixes the issue.

While this library is almost never useful on Android, Android is probably not the only platform with a "broken" SecurityManager implementation.